### PR TITLE
Component guard clauses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 Changes worth mentioning.
 
 ---
+## 0.20.0 - 2018-04-27
+- [Feature] Components render nothing if properties equal false
+
 ## 0.19.0 - 2017-09-08
 - [Feature] Index showing one example of each component
 - [Improvement] Default properties visible on component pages

--- a/app/helpers/fenrir_view/component_helper.rb
+++ b/app/helpers/fenrir_view/component_helper.rb
@@ -1,6 +1,8 @@
 module FenrirView
   module ComponentHelper
     def render_ui(variant, slug, properties = {}, &block)
+      return nil if properties == false
+
       component = FenrirView::Presenter.component_for(variant, slug, properties)
       component.render(controller.view_context) do
         capture(&block) if block_given?

--- a/lib/fenrir_view/version.rb
+++ b/lib/fenrir_view/version.rb
@@ -1,3 +1,3 @@
 module FenrirView
-  VERSION = "0.19.0".freeze
+  VERSION = '0.20.0'.freeze
 end


### PR DESCRIPTION
If you set a components properties to `false` it does not get rendered.

This allows us to use guard clauses in our facades, instead of if statements in our views.

**Before**:
```erb
<% if @content.details_policy.can_update_key_dates? %>
  <%= ui_component("button", @content.new_key_date_button) %>
<% end %>
```
```ruby
def new_key_date_button
  {...}
end
```

**After**:
```erb
<%= ui_component("button", @content.new_key_date_button) %>
```
```ruby
def new_key_date_button
  return false unless details_policy.can_update_key_dates?
  {...}
end
```