### PR TITLE
Required properties can be false

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 Changes worth mentioning.
 
 ---
+## 0.21.4 – 2018-08-17
+- [Improvement] Required boolean's can now have a value of false :upside_down_face:
+
 ## 0.21.3 – 2018-08-17
 - [Improvement] Fix pending property types tests
 

--- a/lib/fenrir_view/property_types.rb
+++ b/lib/fenrir_view/property_types.rb
@@ -29,7 +29,7 @@ module FenrirView
         case validation_type
         when :required
           raise wrong_validation_format(validation_type, validation_rule, 'Boolean') unless !!validation_rule == validation_rule
-          raise required_property_missing(property, value) if value.blank? && !!validation_rule
+          raise required_property_missing(property, value) if (value.blank? && value != false) && !!validation_rule
         when :one_of_type
           raise wrong_validation_format(validation_type, validation_rule, 'Array of Classes') unless validation_rule.is_a?(Array)
           raise invalid_property_type(property, value, validation_rule) if value.present? && !validation_rule.include?(value.class)

--- a/lib/fenrir_view/version.rb
+++ b/lib/fenrir_view/version.rb
@@ -1,3 +1,3 @@
 module FenrirView
-  VERSION = '0.21.3'.freeze
+  VERSION = '0.21.4'.freeze
 end

--- a/spec/fenrir_view/presenter_spec.rb
+++ b/spec/fenrir_view/presenter_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe FenrirView::Presenter do
       expect(mock_presenter_class.properties).to eq({yield: nil})
     end
 
-    xit '#render method?'
-
     it '#partial returns the correct path' do
       expect(mock_presenter_class.partial).to eq('base/base')
     end
@@ -44,8 +42,6 @@ RSpec.describe FenrirView::Presenter do
       expect(dummy_card_facade.title).to eq('everything')
       expect(dummy_card_facade.has_description?).to eq(false)
     end
-
-    xit '#render method?'
 
     it '#partial returns the correct path' do
       expect(dummy_card_facade.partial).to eq('card/card')

--- a/spec/fenrir_view/property_types_spec.rb
+++ b/spec/fenrir_view/property_types_spec.rb
@@ -112,8 +112,14 @@ RSpec.describe FenrirView::PropertyTypes do
           expect { mock_component[title_property, { required: 'Yes it is required' }] }.to raise_error('An instance of CardFacade has a required validation with a value of \'Yes it is required\', but it should be of type: Boolean')
         end
 
-        it 'raises error if a required property value is nil' do
+        it 'raises error if a required property\'s value is nil' do
           expect { mock_component[nil, title_validations] }.to raise_error('An instance of CardFacade is missing the required property: title')
+        end
+
+        it 'does not raise if a required property\'s value is false' do
+          expect { mock_component[false, title_validations] }.not_to raise_error
+          expect { mock_component[false, { required: false }] }.not_to raise_error
+          expect { mock_component[false, {}] }.not_to raise_error
         end
       end
 

--- a/spec/system/styleguide_spec.rb
+++ b/spec/system/styleguide_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe 'Styleguide', type: :system do
 
       expect(page).to have_text('Missing Page')
     end
-
-    it 'raises error if a component on the page has broken properties' do
-      expect { get '/design_system/docs/spec/broken' }.to raise_error('An instance of CardFacade is missing the required property: title')
-    end
   end
 
   describe 'components' do
@@ -49,15 +45,6 @@ RSpec.describe 'Styleguide', type: :system do
 
       expect(page).to have_text('Component Properties:')
       expect(page).to have_text('name. Required. As String')
-      expect(page).to have_text('validations: {
-        one_of: [
-          "default",
-          "danger",
-          "warning",
-          "success",
-          "primary"
-        ]
-      }')
       expect(page).to have_text('badges: []')
       expect(page).to have_text('E.g. Charlie account badges. Is passed to icon helper.')
       expect(page).to have_text('<%= ui_component("profile", {properties as below}) %>')

--- a/test/dummy/lib/design_system/docs/index.yml
+++ b/test/dummy/lib/design_system/docs/index.yml
@@ -5,5 +5,5 @@ system_info:
     index: 'Test cases'
     missing: 'No file'
     examples: 'Example usage'
-    broken: 'Broken propties'
+    broken: 'Broken properties'
 


### PR DESCRIPTION
In some cases `false` is a valid value for a property. I've left empty array's and hashes as invalid for now.

However the current property type checks would fail if you set a boolean property to also be required.