### PR TITLE
Hide counts in production

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 Changes worth mentioning.
 
 ---
+## 0.25.1 - 2019-03-08
+- [Improvement] Only show component usuage metrics in developement and test enviroments
+
 ## 0.25.0 - 2019-03-06
 - [Feature] Generate usage metrics for your app by running `rails design_system:generate_metrics`
 - [Feature] Show usage of components in styleguide

--- a/app/facades/fenrir_view/styleguide_facade.rb
+++ b/app/facades/fenrir_view/styleguide_facade.rb
@@ -28,7 +28,8 @@ module FenrirView
     end
 
     def top_line_metrics
-      return [] if metrics.nil?
+      return [] if !metrics.present? || Rails.env.production?
+
       [
         "System saturation: #{metrics.dig(:totals, :saturation)}%",
         "Total component instances: #{metrics.dig(:totals, :components)}",
@@ -44,6 +45,8 @@ module FenrirView
 
     def metrics
       @metrics ||= YAML.load_file(Rails.root.join('lib', 'design_system', 'metrics.yml')).dig(:design_system, :metrics) || {}
+    rescue Errno::ENOENT
+      {}
     end
   end
 end

--- a/lib/fenrir_view/component.rb
+++ b/lib/fenrir_view/component.rb
@@ -104,17 +104,23 @@ module FenrirView
         [
           ('Low usage!' if health.low_usage?),
           "Health: #{health.score}%",
-          '(',
-          [
-            "Healthy instances: #{health.component_usage_count}",
-            "Property hashes: #{health.property_hashes_count}",
-            "Deprecated instances: #{health.component_deprecated_count}",
-          ].join(' | '),
-          ')',
+          component_usage,
         ].compact.join(' ')
       else
         'Metrics for this component is unavailable 😞'
       end
+    end
+
+    def component_usage
+      return nil if Rails.env.production?
+
+      [
+        '(',
+        "Healthy instances: #{health.component_usage_count}",
+        "Property hashes: #{health.property_hashes_count}",
+        "Deprecated instances: #{health.component_deprecated_count}",
+        ')',
+      ].join(' ')
     end
 
     def stubs_correct_format?

--- a/lib/fenrir_view/version.rb
+++ b/lib/fenrir_view/version.rb
@@ -1,3 +1,3 @@
 module FenrirView
-  VERSION = '0.25.0'.freeze
+  VERSION = '0.25.1'.freeze
 end


### PR DESCRIPTION
This hides the component instance counts from showing up in production. The health score and low usage warning is still visible.