### PR TITLE
Update FenrirView::Engine for Rails 6 and Zeitwerk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ rails = case rails_version
         when "master"
           { github: "rails/rails" }
         when "default"
-          ">= 3.2.0"
+          "~> 6.0"
         else
           "~> #{rails_version}"
         end
@@ -20,7 +20,7 @@ gem "rails", rails
 gem 'jquery-rails'
 gem 'jquery-ui-rails', '~> 6.0'
 
-gem 'sass-rails', '~> 5.0', '>= 5.0.6'
+gem 'sass-rails', '~> 6.0'
 gem 'fenrir', git: 'https://github.com/jsundt/fenrir', branch: "master"
 
 # Declare any dependencies that are still in development here instead of in

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 Changes worth mentioning.
 
 ---
+## 0.30.1 - 2019-08-29
+- [Improvement] Updated bundle
+- [Fix] Fixed tests that was forgotten with a previous change
+
 ## 0.30.0 - 2019-08-29
 - [Improvement] Updated javascript component template
 - [Improvement] Standardised the javascript for our system components

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 Changes worth mentioning.
 
 ---
+## 1.0.0 - 2021-04-13
+- [Fix] Add support Rails 6.0 Zeitwerk autoloader
+- [Breaking] Dropped support for Rails 5 and below
+
 ## 0.30.1 - 2019-08-29
 - [Improvement] Updated bundle
 - [Fix] Fixed tests that was forgotten with a previous change

--- a/fenrir_view.gemspec
+++ b/fenrir_view.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*', 'spec/**/*']
 
-  s.add_dependency 'rails', '>= 3.2.0'
+  s.add_dependency 'rails', '>= 6.0.0'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'puma'

--- a/fenrir_view.gemspec
+++ b/fenrir_view.gemspec
@@ -19,10 +19,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 3.2.0'
   s.add_development_dependency 'capybara'
-  s.add_development_dependency 'chromedriver-helper'
   s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'puma'
-  s.add_development_dependency 'rspec-rails', '~> 3.7.2'
+  s.add_development_dependency 'json'
+  s.add_development_dependency 'rspec-rails', '~> 4'
+  s.add_development_dependency 'webdrivers', '~> 4.0'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
 end

--- a/lib/fenrir_view/engine.rb
+++ b/lib/fenrir_view/engine.rb
@@ -52,7 +52,7 @@ module FenrirView
     end
 
     initializer 'fenrir_view.add_helpers' do
-      ActiveSupport.on_load :action_controller do
+      Rails.application.reloader.to_prepare do
         ::ActionController::Base.helper FenrirView::ComponentHelper
       end
     end

--- a/lib/fenrir_view/version.rb
+++ b/lib/fenrir_view/version.rb
@@ -1,3 +1,3 @@
 module FenrirView
-  VERSION = '0.30.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/spec/fenrir_view/presenter_spec.rb
+++ b/spec/fenrir_view/presenter_spec.rb
@@ -50,39 +50,39 @@ RSpec.describe FenrirView::Presenter do
     it '#component_property_rule_descriptions' do
       expect(dummy_card_facade.component_property_rule_descriptions).to eq({
         yield: {
-          info: '',
+          default: nil,
           note: nil,
-          validations: {},
+          validations: { required: false },
         },
         title: {
-          info: '. Required',
+          default: nil,
           note: nil,
-          validations: {},
+          validations: { required: true },
         },
         description: {
-          info: '',
+          default: nil,
           note: nil,
-          validations: {},
+          validations: { required: false },
         },
         link: {
-          info: '',
+          default: nil,
           note: nil,
-          validations: {},
+          validations: { required: false },
         },
         image_url: {
-          info: '',
+          default: nil,
           note: nil,
-          validations: {},
+          validations: { required: false },
         },
         location: {
-          info: '',
+          default: nil,
           note: nil,
-          validations: {},
+          validations: { required: false },
         },
         data: {
-          info: ': []',
+          default: [],
           note: nil,
-          validations: {},
+          validations: { required: false },
         },
       })
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ end
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../test/dummy/config/environment', __dir__)
 
+require 'webdrivers/chromedriver'
 require 'selenium-webdriver'
 require 'rspec/rails'
 require 'spec_helper'

--- a/spec/system/styleguide_spec.rb
+++ b/spec/system/styleguide_spec.rb
@@ -206,8 +206,8 @@ RSpec.describe 'Styleguide', type: :system do
         expect(page).to have_text('Healthy. Low usage')
 
         find('.spec-component-properties', text: 'Component properties').click
-        expect(page).to have_text('name. Required. As String')
-        expect(page).to have_text('badges: []')
+        expect(page).to have_text('name Required One Of Type: String', normalize_ws: true)
+        expect(page).to have_text('badges []')
         expect(page).to have_text('E.g. Charlie account badges. Is passed to icon helper.')
 
         find('button[data-spec="regular_profile"]').click

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css


### PR DESCRIPTION
In order to safely autoload FenrirView::ComponentHelper through Zeitwerk we need to do it via the reloader to_prepare block. This allows changes made to classes and modules which are loaded at initialization time can be reloaded in development.

https://guides.rubyonrails.org/autoloading_and_reloading_constants.html

Because this required increasing the minimum Rails version from 3.2 to 6.0 I've considered this a major breaking change and increased the major version number from 0 to 1. Some alternative options:

1. Update the code with a Rails version check that only does the new behaviour on 6.0 and above
2. Keep the "0" major version number and bump this to 0.40.0 or 0.31.0 (the "0" indicating that this is in beta still?)

I think (1) would look something like:

```
    initializer 'fenrir_view.add_helpers' do
      if Gem::Version.new(Rails.version) >= Gem::Version.new('6.0.0.0')
        Rails.application.reloader.to_prepare do
          ::ActionController::Base.helper FenrirView::ComponentHelper
        end
      else
        ActiveSupport.on_load :action_controller do
          ::ActionController::Base.helper FenrirView::ComponentHelper
        end
      end
    end
```