### PR TITLE
Add components preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'jquery-ui-rails', '~> 6.0'
 
 gem 'sass-rails', '~> 6.0'
 gem 'fenrir', git: 'https://github.com/jsundt/fenrir', branch: "master"
+gem 'pry'
 
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 Changes worth mentioning.
 
 ---
+## 1.1.0 - 2021-07-15
+- [Improvement] Add pry gem to Gemfile
+- [Improvement] Add component preview pages
+
 ## 1.0.0 - 2021-04-13
 - [Fix] Add support Rails 6.0 Zeitwerk autoloader
 - [Breaking] Dropped support for Rails 5 and below

--- a/app/controllers/fenrir_view/styleguide_controller.rb
+++ b/app/controllers/fenrir_view/styleguide_controller.rb
@@ -2,14 +2,22 @@
 
 module FenrirView
   class StyleguideController < FenrirController
+    before_action :set_component, only: [:show, :preview]
+
     helper 'fenrir_view/styleguide'
 
     def index; end
 
     def show
-      @component = FenrirView::Component.new(params[:variant], params[:id], design_system_policy: @design_system_policy)
-
       render 'fenrir_view/styleguide/missing' unless @component.facade_loaded?
+    end
+
+    def preview
+      render layout: 'plain'
+    end
+
+    def set_component
+      @component = FenrirView::Component.new(params[:variant], params[:id], design_system_policy: @design_system_policy)
     end
   end
 end

--- a/app/views/fenrir_view/styleguide/preview.html.erb
+++ b/app/views/fenrir_view/styleguide/preview.html.erb
@@ -1,53 +1,19 @@
 <h2><%= @component.name.titleize %></h2>
 
-<% @component.stub_properties.each_with_index do |property, property_index| %>
-  <div class="fenrir-view-component-example__examples-wrapper">
-    <% @component.devices.each_with_index do |device, device_index| %>
-        <iframe id="<%= @component.name%>-<%= property_index %>-<%= device_index %>" width="<%= device.width %>" height="<%= device.height %>" name="<%= device.name %>" srcdoc='
-          <script type="text/javascript">
-            window.onload = function() {
-              if (parent) {
-                var oHead = document.getElementsByTagName("head")[0];
-                var arrStyleSheets = parent.document.getElementsByTagName("link");
-                var arrJavaScript = parent.document.getElementsByTagName("script");
-
-                for (var i = 0; i < arrStyleSheets.length; i++) {
-                  oHead.appendChild(arrStyleSheets[i].cloneNode(true));
-                }
-
-                for (var i = 0; i < arrJavaScript.length; i++) {
-                  var script = document.createElement("script");
-                  script.type = "text/javascript";
-
-                  if (arrJavaScript[i].src) {
-                    script.src = arrJavaScript[i].src;
-                    oHead.appendChild(script);
-                  }
-                }
-
-                document.body.classList.add("fenrir-view-component-example__content-body")
-              }
-            }
-          </script>
-          <div>
-              <%= ui_component( @component.name, property.fetch(:properties)) do |layout| %>
-                <% @component.yields(property.fetch(:yields)).each do |content| %>
-                  <% if content.key? && content.args.any? %>
-                    <% layout.public_send(content.key, content.args) do %>
-                      <%= content.content %>
-                    <% end %>
-                  <% elsif content.key? %>
-                    <% layout.public_send(content.key) do %>
-                      <%= content.content %>
-                    <% end %>
-                  <% else %>
-                    <%= content.content %>
-                  <% end %>
-                <% end%>
-              <% end %>
-          </div>
-        '>
-        </iframe>
-    <% end %>
-  </div>
+<% @component.stub_properties.each do |property| %>
+  <%= ui_component( @component.name, property.fetch(:properties)) do |layout| %>
+    <% @component.yields(property.fetch(:yields)).each do |content| %>
+      <% if content.key? && content.args.any? %>
+        <% layout.public_send(content.key, content.args) do %>
+          <%= content.content %>
+        <% end %>
+      <% elsif content.key? %>
+        <% layout.public_send(content.key) do %>
+          <%= content.content %>
+        <% end %>
+      <% else %>
+        <%= content.content %>
+      <% end %>
+    <% end%>
+  <% end %>
 <% end %>

--- a/app/views/fenrir_view/styleguide/preview.html.erb
+++ b/app/views/fenrir_view/styleguide/preview.html.erb
@@ -1,0 +1,53 @@
+<h2><%= @component.name.titleize %></h2>
+
+<% @component.stub_properties.each_with_index do |property, property_index| %>
+  <div class="fenrir-view-component-example__examples-wrapper">
+    <% @component.devices.each_with_index do |device, device_index| %>
+        <iframe id="<%= @component.name%>-<%= property_index %>-<%= device_index %>" width="<%= device.width %>" height="<%= device.height %>" name="<%= device.name %>" srcdoc='
+          <script type="text/javascript">
+            window.onload = function() {
+              if (parent) {
+                var oHead = document.getElementsByTagName("head")[0];
+                var arrStyleSheets = parent.document.getElementsByTagName("link");
+                var arrJavaScript = parent.document.getElementsByTagName("script");
+
+                for (var i = 0; i < arrStyleSheets.length; i++) {
+                  oHead.appendChild(arrStyleSheets[i].cloneNode(true));
+                }
+
+                for (var i = 0; i < arrJavaScript.length; i++) {
+                  var script = document.createElement("script");
+                  script.type = "text/javascript";
+
+                  if (arrJavaScript[i].src) {
+                    script.src = arrJavaScript[i].src;
+                    oHead.appendChild(script);
+                  }
+                }
+
+                document.body.classList.add("fenrir-view-component-example__content-body")
+              }
+            }
+          </script>
+          <div>
+              <%= ui_component( @component.name, property.fetch(:properties)) do |layout| %>
+                <% @component.yields(property.fetch(:yields)).each do |content| %>
+                  <% if content.key? && content.args.any? %>
+                    <% layout.public_send(content.key, content.args) do %>
+                      <%= content.content %>
+                    <% end %>
+                  <% elsif content.key? %>
+                    <% layout.public_send(content.key) do %>
+                      <%= content.content %>
+                    <% end %>
+                  <% else %>
+                    <%= content.content %>
+                  <% end %>
+                <% end%>
+              <% end %>
+          </div>
+        '>
+        </iframe>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/layouts/plain.html.erb
+++ b/app/views/layouts/plain.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+
+    <title><% if content_for?(:page_title) %><%= yield(:page_title) %><% else %>Charlie Design System<% end %></title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="format-detection" content="telephone=no">
+
+    <%= stylesheet_link_tag 'fenrir_view/styleguide', media: 'all', 'data-turbolinks-track' => true %>
+    <%= javascript_include_tag 'fenrir_view/styleguide', 'data-turbolinks-track' => true %>
+
+    <%= csrf_meta_tags %>
+
+    <!-- Load Webfonts -->
+    <% unless Rails.env.test? %>
+      <link rel="stylesheet" href="https://use.typekit.net/ler6yzq.css">
+    <% end %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ FenrirView::Engine.routes.draw do
   # Component pages
   get 'components', to: 'styleguide#index', as: 'component_index'
   get 'components/:id', to: 'styleguide#show', as: 'components', defaults: { variant: 'components' }
+  get 'components/:id/preview', to: 'styleguide#preview', as: 'preview', defaults: { variant: 'components' }
 
   # Custom documentation pages
   get ':section(/:page)', to: 'docs#show', as: 'fenrir_docs', constraints: FenrirView::Documentation.new

--- a/lib/fenrir_view/component.rb
+++ b/lib/fenrir_view/component.rb
@@ -16,6 +16,9 @@ module FenrirView
              :stubs_correct_format?,
              :stubs_are_a_hash_with_info?,
              :component_meta_info?,
+             :stub_properties,
+             :yields,
+             :devices,
              to: :examples
 
     delegate :can_access_metrics?, to: :health

--- a/lib/fenrir_view/component.rb
+++ b/lib/fenrir_view/component.rb
@@ -18,7 +18,6 @@ module FenrirView
              :component_meta_info?,
              :stub_properties,
              :yields,
-             :devices,
              to: :examples
 
     delegate :can_access_metrics?, to: :health

--- a/lib/fenrir_view/component/examples.rb
+++ b/lib/fenrir_view/component/examples.rb
@@ -77,6 +77,50 @@ module FenrirView
         FenrirView.pattern_type(variant).join(identifier, "#{identifier}.yml")
       end
 
+      def stub_properties
+        component_examples.flat_map do |stub|
+          if (stub[:yields] || stub[:props]).present?
+            [{
+              properties: stub.fetch(:props, nil) || stub.fetch(:properties, {}),
+              yields: stub.fetch(:yields, [])
+            }]
+          elsif stub[:examples]
+            stub.fetch(:examples).map do |example|
+              {
+                properties: example.fetch(:properties, {}),
+                yields: example.fetch(:yields, [])
+              }
+            end
+          else
+            {}
+          end
+        end
+      end
+
+      def yields(array)
+        @yields ||= array.map do |content|
+          OpenStruct.new(
+            key?: content[:key].present?,
+            key: content.fetch(:key, nil)&.to_sym,
+            args: content.fetch(:args, {}),
+            content: content.fetch(:content),
+          )
+        end
+      end
+
+      def devices
+        [
+          OpenStruct.new(
+            width: '320px',
+            height: '500px'
+          ),
+          OpenStruct.new(
+            width: '1200px',
+            height: '500px'
+          )
+        ]
+      end
+
       private
 
       def component_examples

--- a/lib/fenrir_view/component/examples.rb
+++ b/lib/fenrir_view/component/examples.rb
@@ -103,22 +103,9 @@ module FenrirView
             key?: content[:key].present?,
             key: content.fetch(:key, nil)&.to_sym,
             args: content.fetch(:args, {}),
-            content: content.fetch(:content),
+            content: content.fetch(:content)
           )
         end
-      end
-
-      def devices
-        [
-          OpenStruct.new(
-            width: '320px',
-            height: '500px'
-          ),
-          OpenStruct.new(
-            width: '1200px',
-            height: '500px'
-          )
-        ]
       end
 
       private

--- a/lib/fenrir_view/version.rb
+++ b/lib/fenrir_view/version.rb
@@ -1,3 +1,3 @@
 module FenrirView
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/system/styleguide_spec.rb
+++ b/spec/system/styleguide_spec.rb
@@ -329,4 +329,44 @@ RSpec.describe 'Styleguide', type: :system do
       expect(page).to have_text('Examples of components together')
     end
   end
+
+  describe '/previews' do
+    components = [
+      {
+        name: 'card',
+        content: 'Aspen Snowmass is a winter resort complex located in Pitkin County in western Colorado'
+      },
+      {
+        name: 'collection',
+        content: '20 Mountains you didn\'t know they even existed'
+      },
+      {
+        name: 'header',
+        content: '20 Mountains you didn\'t know they even existed'
+      },
+      {
+        name: 'layout',
+        content: '20 Mountains you didn\'t know they even existed'
+      },
+      {
+        name: 'profile',
+        content: 'Johnny'
+      },
+      {
+        name: 'yielder',
+        content: 'Tell me about the Proc?'
+      }
+    ].freeze
+
+    it 'component previews' do
+      components.each do |component|
+        visit "/design_system/components/#{component[:name]}/preview"
+
+        expect(page).to have_text(component[:name].titleize)
+        within_frame(find("##{component[:name]}-0-0")) do
+          expect(page).to have_content(component[:content])
+        end
+      end
+    end
+  end
 end

--- a/spec/system/styleguide_spec.rb
+++ b/spec/system/styleguide_spec.rb
@@ -363,9 +363,8 @@ RSpec.describe 'Styleguide', type: :system do
         visit "/design_system/components/#{component[:name]}/preview"
 
         expect(page).to have_text(component[:name].titleize)
-        within_frame(find("##{component[:name]}-0-0")) do
-          expect(page).to have_content(component[:content])
-        end
+
+        expect(page).to have_content(component[:content])
       end
     end
   end


### PR DESCRIPTION
**Add pry gem to Gemfile**


**Add components/:id/preview route**

The preview page displays the different states of a component on a plain layout.
The states are displayed inside two different iframes for mobile and desktop devices.

**Remove iframes and mobile version from preview**

**Bump version to 1.1.0**