### PR TITLE
Ruby 3 kwarg updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3.0
 
       - name: Bundle install
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@
 Changes worth mentioning.
 
 ---
+## 1.3.1 - 2023-01-09
+- [Fix] Fixed keyword argument depreciation warnings for Ruby 3.
+- [Improvement] Updated webdrivers gem from 4.0 to 5.2.0, fixes issues running selenium specs on an M1 Mac
+- [Fix] Update config to fix CI build failure
+
 ## 1.3.0 - 2021-08-11
 - [Improvement] Add Accessibility Reports for pages
 - [Fix] Fixed bug in the component preview pages

--- a/app/helpers/fenrir_view/component_helper.rb
+++ b/app/helpers/fenrir_view/component_helper.rb
@@ -5,7 +5,7 @@ module FenrirView
     def ui_component(slug, properties = {}, &_block)
       return nil if properties == false
 
-      component = FenrirView::Presenter.component_for('components', slug, properties, validate: true)
+      component = FenrirView::Presenter.component_for(variant: 'components', slug: slug, properties: properties, validate: true)
 
       if block_given?
         if component.respond_to?(:layout)
@@ -29,7 +29,7 @@ module FenrirView
     def system_component(slug, properties = {}, &_block)
       return nil if properties == false
 
-      component = FenrirView::Presenter.component_for('system', "fenrir_view_#{slug}", properties, validate: true)
+      component = FenrirView::Presenter.component_for(variant: 'system', slug: "fenrir_view_#{slug}", properties: properties, validate: true)
 
       component.render(controller.view_context) do
         capture { yield } if block_given?

--- a/fenrir_view.gemspec
+++ b/fenrir_view.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'puma'
   s.add_development_dependency 'json'
   s.add_development_dependency 'rspec-rails', '~> 4'
-  s.add_development_dependency 'webdrivers', '~> 4.0'
+  s.add_development_dependency 'webdrivers', '~> 5.2.0'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
 end

--- a/lib/fenrir_view/component.rb
+++ b/lib/fenrir_view/component.rb
@@ -96,7 +96,7 @@ module FenrirView
     private
 
     def component_facade
-      @component_facade ||= FenrirView::Presenter.component_for(variant, component_identifier, {}, validate: false)
+      @component_facade ||= FenrirView::Presenter.component_for(variant: variant, slug: component_identifier, properties: {}, validate: false)
     rescue FenrirView::Presenter::MissingFacadeError
       false
     end

--- a/lib/fenrir_view/components/fenrir_view_component_example/_fenrir_view_component_example.html.erb
+++ b/lib/fenrir_view/components/fenrir_view_component_example/_fenrir_view_component_example.html.erb
@@ -36,7 +36,7 @@
               <%= public_send(example.helper_start, example.component, example.properties) do |layout| %>
                 <% example.yields.each do |content| %>
                   <% if content.key? && content.args.any? %>
-                    <% layout.public_send(content.key, content.args) do %>
+                    <% layout.public_send(content.key, **content.args) do %>
                       <%= content.content %>
                     <% end %>
                   <% elsif content.key? %>

--- a/lib/fenrir_view/presenter.rb
+++ b/lib/fenrir_view/presenter.rb
@@ -9,7 +9,7 @@ module FenrirView
 
     attr_reader :variant, :slug, :properties
 
-    def initialize(variant, slug, properties = {}, validate: true)
+    def initialize(variant:, slug:, properties: {}, validate: true)
       @variant = variant
       @slug = slug
       @properties = default_properties.deep_merge(properties)
@@ -56,11 +56,11 @@ module FenrirView
     class MissingFacadeError < ArgumentError; end
 
     class << self
-      def component_for(*args)
-        klass = "#{args.second.to_s.camelize}Facade".safe_constantize
-        raise ::FenrirView::Presenter::MissingFacadeError.new("Could not find component: #{args.first.to_s}: #{args.second.to_s}") unless !!klass
+      def component_for(args)
+        klass = "#{args[:slug].to_s.camelize}Facade".safe_constantize
+        raise ::FenrirView::Presenter::MissingFacadeError.new("Could not find component: #{args[:variant].to_s}: #{args[:slug].to_s}") unless !!klass
 
-        klass.new(*args)
+        klass.new(**args)
       end
 
       def properties(*args)

--- a/lib/fenrir_view/version.rb
+++ b/lib/fenrir_view/version.rb
@@ -1,3 +1,3 @@
 module FenrirView
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.1'.freeze
 end

--- a/spec/fenrir_view/metrics_spec.rb
+++ b/spec/fenrir_view/metrics_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FenrirView::Metrics do
     allow(subject).to receive(:puts).and_return(nil)
     allow(subject).to receive(:printf).and_return(nil)
     allow(subject).to receive(:metrics_file) do
-      Dir.mkdir('tmp') unless File.exists?('tmp')
+      Dir.mkdir('tmp') unless File.exist?('tmp')
 
       File.new(path_to_metrics_file, 'w')
     end

--- a/spec/fenrir_view/presenter_spec.rb
+++ b/spec/fenrir_view/presenter_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe FenrirView::Presenter do
   describe 'Presenter class' do
-    let(:mock_presenter_class) { FenrirView::Presenter.new('component', 'base', {}, validate: false) }
+    let(:mock_presenter_class) { FenrirView::Presenter.new(variant: 'component', slug: 'base', properties: {}, validate: false) }
 
     it 'initializes with correct variables' do
       expect(mock_presenter_class.variant).to eq('component')
@@ -19,7 +19,7 @@ RSpec.describe FenrirView::Presenter do
 
   describe '#component_for initilizes facade inheriting presenter' do
     let(:dummy_card_facade) {
-      FenrirView::Presenter.component_for('component', 'card', { title: 'everything' }, validate: false)
+      FenrirView::Presenter.component_for(variant: 'component', slug: 'card', properties: { title: 'everything' }, validate: false)
     }
 
     it 'finds correct component facade' do
@@ -89,7 +89,7 @@ RSpec.describe FenrirView::Presenter do
 
     describe '#validate_properties' do
       let(:invalid_card_facade) {
-        FenrirView::Presenter.component_for('component', 'card', { not_a_property: 'everything' }, validate: false)
+        FenrirView::Presenter.component_for(variant: 'component', slug: 'card', properties: { not_a_property: 'everything' }, validate: false)
       }
 
       it 'validates correctly if validations are met' do

--- a/spec/fenrir_view/property_types_spec.rb
+++ b/spec/fenrir_view/property_types_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 RSpec.describe FenrirView::PropertyTypes do
   let(:mock_instance) do
     lambda { |instance_props, component_props|
-      FenrirView::PropertyTypes.new({
+      FenrirView::PropertyTypes.new(
                                       component_class: CardFacade,
                                       component_properties: component_props,
                                       instance_properties: instance_props,
-                                    })
+                                    )
     }
   end
 
@@ -25,7 +25,7 @@ RSpec.describe FenrirView::PropertyTypes do
 
   describe 'Presenter initializes validator' do
     let(:card_facade_property_types) {
-      FenrirView::Presenter.component_for('component', 'card', {
+      FenrirView::Presenter.component_for(variant: 'component', slug: 'card', properties: {
         title: 'everything',
       }, validate: true).send(:property_types)
     }


### PR DESCRIPTION
- Fixes kwarg depreciation warnings that appeared in test suite.
- Updates webdrivers from 4.0 to 5.2.0 to allow the selenium specs to run on an M1 mac (https://github.com/titusfortner/webdrivers/releases/tag/v5.2.0)
- Updates config to fix CI build error
- Bump version 1.3.0 -> 1.3.1